### PR TITLE
Enhance geometry pipeline with sanity guards and hint mapping

### DIFF
--- a/apps/cas/compute.py
+++ b/apps/cas/compute.py
@@ -409,4 +409,28 @@ def run_geocas(constraint_spec: Optional[Dict] = None,
             tx, ty = -math.sin(tval), math.cos(tval)
             exact["tangent_dirs"][lbl] = [float(tx), float(ty)]
 
+    # Degeneracy/Incidence guards
+    pts = exact.get("points", {})
+    labels = list(pts.keys())
+
+    def _dist(p, q):
+        return math.hypot(p[0] - q[0], p[1] - q[1])
+
+    def _collinear(p, a, b, eps=1e-9):
+        return abs((a[0] - p[0]) * (b[1] - p[1]) - (a[1] - p[1]) * (b[0] - p[0])) < eps
+
+    for i in range(len(labels)):
+        for j in range(i + 1, len(labels)):
+            if _dist(pts[labels[i]], pts[labels[j]]) < 1e-6:
+                raise ValueError(
+                    f"Degenerate geometry: {labels[i]} ≈ {labels[j]} (distance < 1e-6)"
+                )
+
+    for c in constraints:
+        if isinstance(c, dict) and c.get("type") == "noncollinear":
+            X, Y, Z = c.get("points", [None, None, None])
+            if X in pts and Y in pts and Z in pts:
+                if _collinear(pts[X], pts[Y], pts[Z]):
+                    raise ValueError(f"Noncollinear violated: {X},{Y},{Z} are collinear")
+
     return exact


### PR DESCRIPTION
## Summary
- Sanitize LLM geometry constraints with auto-added distinct/noncollinear/polygon_order guards
- Respect points_hint_map by pinning OCR-detected keypoints to geometry labels
- Add degeneracy and incidence guards after GeoCAS solve for robust pipeline

## Testing
- `pytest` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68bd907f0ccc832ebdf0586f03581901